### PR TITLE
Add CDK Name to ACT

### DIFF
--- a/src/abstract_canister_tree.rs
+++ b/src/abstract_canister_tree.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 
-use crate::nodes::act_init_method::Context;
+use crate::nodes::{act_external_canister, act_init_method, act_post_upgrade_method};
 
 use super::{
     generators::{candid_file_generation, random, vm_value_conversion},
@@ -50,17 +50,29 @@ impl ToTokenStream<()> for AbstractCanisterTree {
 
         let func_arg_token = data_type_nodes::generate_func_arg_token();
 
-        let cross_canister_functions = self.external_canisters.to_token_streams(&self.keywords);
+        let cross_canister_functions =
+            self.external_canisters
+                .to_token_streams(act_external_canister::TokenStreamContext {
+                    cdk_name: &self.cdk_name,
+                    keyword_list: &self.keywords,
+                });
 
         let user_defined_code = &self.rust_code;
 
         let heartbeat_method = self.heartbeat_method.to_token_stream(&self.cdk_name);
-        let init_method = self.init_method.to_token_stream(Context {
-            cdk_name: &self.cdk_name,
-            keyword_list: &self.keywords,
-        });
+        let init_method = self
+            .init_method
+            .to_token_stream(act_init_method::TokenStreamContext {
+                cdk_name: &self.cdk_name,
+                keyword_list: &self.keywords,
+            });
         let inspect_message_method = self.inspect_message_method.to_token_stream(&self.cdk_name);
-        let post_upgrade_method = self.post_upgrade_method.to_token_stream(&self.keywords);
+        let post_upgrade_method =
+            self.post_upgrade_method
+                .to_token_stream(act_post_upgrade_method::TokenStreamContext {
+                    cdk_name: &self.cdk_name,
+                    keyword_list: &self.keywords,
+                });
         let pre_upgrade_method = self.pre_upgrade_method.to_token_stream(&self.cdk_name);
 
         let query_methods = self.query_methods.to_token_streams(&self.keywords);

--- a/src/abstract_canister_tree.rs
+++ b/src/abstract_canister_tree.rs
@@ -61,7 +61,7 @@ impl ToTokenStream<()> for AbstractCanisterTree {
         });
         let inspect_message_method = self.inspect_message_method.to_token_stream(&self.cdk_name);
         let post_upgrade_method = self.post_upgrade_method.to_token_stream(&self.keywords);
-        let pre_upgrade_method = self.pre_upgrade_method.to_token_stream(());
+        let pre_upgrade_method = self.pre_upgrade_method.to_token_stream(&self.cdk_name);
 
         let query_methods = self.query_methods.to_token_streams(&self.keywords);
         let update_methods = self.update_methods.to_token_streams(&self.keywords);

--- a/src/abstract_canister_tree.rs
+++ b/src/abstract_canister_tree.rs
@@ -59,7 +59,7 @@ impl ToTokenStream<()> for AbstractCanisterTree {
             cdk_name: &self.cdk_name,
             keyword_list: &self.keywords,
         });
-        let inspect_message_method = self.inspect_message_method.to_token_stream(());
+        let inspect_message_method = self.inspect_message_method.to_token_stream(&self.cdk_name);
         let post_upgrade_method = self.post_upgrade_method.to_token_stream(&self.keywords);
         let pre_upgrade_method = self.pre_upgrade_method.to_token_stream(());
 

--- a/src/abstract_canister_tree.rs
+++ b/src/abstract_canister_tree.rs
@@ -54,7 +54,7 @@ impl ToTokenStream<()> for AbstractCanisterTree {
 
         let user_defined_code = &self.rust_code;
 
-        let heartbeat_method = self.heartbeat_method.to_token_stream(());
+        let heartbeat_method = self.heartbeat_method.to_token_stream(&self.cdk_name);
         let init_method = self.init_method.to_token_stream(Context {
             cdk_name: &self.cdk_name,
             keyword_list: &self.keywords,

--- a/src/abstract_canister_tree.rs
+++ b/src/abstract_canister_tree.rs
@@ -1,5 +1,7 @@
 use proc_macro2::TokenStream;
 
+use crate::nodes::act_init_method::Context;
+
 use super::{
     generators::{candid_file_generation, random, vm_value_conversion},
     nodes::{
@@ -14,6 +16,7 @@ use super::{
 
 /// An easily traversable representation of a rust canister
 pub struct AbstractCanisterTree {
+    pub cdk_name: String,
     pub arrays: Vec<ActDataType>,
     pub external_canisters: Vec<ActExternalCanister>,
     pub funcs: Vec<ActDataType>,
@@ -52,7 +55,10 @@ impl ToTokenStream<()> for AbstractCanisterTree {
         let user_defined_code = &self.rust_code;
 
         let heartbeat_method = self.heartbeat_method.to_token_stream(());
-        let init_method = self.init_method.to_token_stream(&self.keywords);
+        let init_method = self.init_method.to_token_stream(Context {
+            cdk_name: &self.cdk_name,
+            keyword_list: &self.keywords,
+        });
         let inspect_message_method = self.inspect_message_method.to_token_stream(());
         let post_upgrade_method = self.post_upgrade_method.to_token_stream(&self.keywords);
         let pre_upgrade_method = self.pre_upgrade_method.to_token_stream(());

--- a/src/nodes/act_external_canister/act_external_canister_method.rs
+++ b/src/nodes/act_external_canister/act_external_canister_method.rs
@@ -13,21 +13,35 @@ pub struct ActExternalCanisterMethod {
 pub struct ActEcmContext<'a> {
     pub canister_name: String,
     pub keyword_list: &'a Vec<String>,
+    pub cdk_name: &'a String,
 }
 
 impl ToTokenStream<ActEcmContext<'_>> for ActExternalCanisterMethod {
     fn to_token_stream(&self, context: ActEcmContext) -> TokenStream {
-        let call_function =
-            self.generate_call_function(&context.canister_name, &context.keyword_list);
-        let call_with_payment_function =
-            self.generate_call_with_payment_function(&context.canister_name, &context.keyword_list);
-        let call_with_payment128_function = self
-            .generate_call_with_payment128_function(&context.canister_name, &context.keyword_list);
-        let notify_function =
-            self.generate_notify_function(&context.canister_name, &context.keyword_list);
+        let call_function = self.generate_call_function(
+            &context.canister_name,
+            &context.keyword_list,
+            &context.cdk_name,
+        );
+        let call_with_payment_function = self.generate_call_with_payment_function(
+            &context.canister_name,
+            &context.keyword_list,
+            &context.cdk_name,
+        );
+        let call_with_payment128_function = self.generate_call_with_payment128_function(
+            &context.canister_name,
+            &context.keyword_list,
+            &context.cdk_name,
+        );
+        let notify_function = self.generate_notify_function(
+            &context.canister_name,
+            &context.keyword_list,
+            &context.cdk_name,
+        );
         let notify_with_payment128_function = self.generate_notify_with_payment128_function(
             &context.canister_name,
             &context.keyword_list,
+            &context.cdk_name,
         );
 
         quote! {
@@ -56,8 +70,9 @@ impl ActExternalCanisterMethod {
         &self,
         canister_name: &String,
         keyword_list: &Vec<String>,
+        cdk_name: &String,
     ) -> TokenStream {
-        let function_name = format_ident!("_azle_call_{}_{}", canister_name, &self.name);
+        let function_name = format_ident!("_{}_call_{}_{}", cdk_name, canister_name, &self.name);
 
         let params = vec![
             vec![quote! { canister_id_principal: ic_cdk::export::Principal }],
@@ -85,9 +100,14 @@ impl ActExternalCanisterMethod {
         &self,
         canister_name: &String,
         keyword_list: &Vec<String>,
+        cdk_name: &String,
     ) -> TokenStream {
-        let function_name =
-            format_ident!("_azle_call_with_payment_{}_{}", canister_name, &self.name);
+        let function_name = format_ident!(
+            "_{}_call_with_payment_{}_{}",
+            cdk_name,
+            canister_name,
+            &self.name
+        );
 
         let params = vec![
             vec![quote! { canister_id_principal: ic_cdk::export::Principal }],
@@ -117,9 +137,11 @@ impl ActExternalCanisterMethod {
         &self,
         canister_name: &String,
         keyword_list: &Vec<String>,
+        cdk_name: &String,
     ) -> TokenStream {
         let function_name = format_ident!(
-            "_azle_call_with_payment128_{}_{}",
+            "_{}_call_with_payment128_{}_{}",
+            cdk_name,
             canister_name,
             &self.name
         );
@@ -152,8 +174,9 @@ impl ActExternalCanisterMethod {
         &self,
         canister_name: &String,
         keyword_list: &Vec<String>,
+        cdk_name: &String,
     ) -> TokenStream {
-        let function_name = format_ident!("_azle_notify_{}_{}", canister_name, &self.name);
+        let function_name = format_ident!("_{}_notify_{}_{}", cdk_name, canister_name, &self.name);
 
         let params = vec![
             vec![quote! { canister_id_principal: ic_cdk::export::Principal }],
@@ -180,9 +203,11 @@ impl ActExternalCanisterMethod {
         &self,
         canister_name: &String,
         keyword_list: &Vec<String>,
+        cdk_name: &String,
     ) -> TokenStream {
         let function_name = format_ident!(
-            "_azle_notify_with_payment128_{}_{}",
+            "_{}_notify_with_payment128_{}_{}",
+            cdk_name,
             canister_name,
             &self.name
         );

--- a/src/nodes/act_external_canister/mod.rs
+++ b/src/nodes/act_external_canister/mod.rs
@@ -15,17 +15,22 @@ pub struct ActExternalCanister {
     pub methods: Vec<ActExternalCanisterMethod>,
 }
 
-impl ActExternalCanister {}
+#[derive(Clone)]
+pub struct TokenStreamContext<'a> {
+    pub keyword_list: &'a Vec<String>,
+    pub cdk_name: &'a String,
+}
 
-impl ToTokenStream<&Vec<String>> for ActExternalCanister {
-    fn to_token_stream(&self, keyword_list: &Vec<String>) -> TokenStream {
+impl ToTokenStream<TokenStreamContext<'_>> for ActExternalCanister {
+    fn to_token_stream(&self, context: TokenStreamContext) -> TokenStream {
         let cross_canister_call_functions: Vec<TokenStream> = self
             .methods
             .iter()
             .map(|method| {
                 method.to_token_stream(ActEcmContext {
                     canister_name: self.name.clone(),
-                    keyword_list: &keyword_list,
+                    keyword_list: &context.keyword_list,
+                    cdk_name: context.cdk_name,
                 })
             })
             .collect();

--- a/src/nodes/act_heartbeat_method.rs
+++ b/src/nodes/act_heartbeat_method.rs
@@ -1,4 +1,5 @@
 use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
 
 use crate::ToTokenStream;
 
@@ -7,12 +8,13 @@ pub struct ActHeartbeatMethod {
     pub body: TokenStream,
 }
 
-impl ToTokenStream<()> for ActHeartbeatMethod {
-    fn to_token_stream(&self, _: ()) -> TokenStream {
+impl ToTokenStream<&String> for ActHeartbeatMethod {
+    fn to_token_stream(&self, cdk_name: &String) -> TokenStream {
+        let function_name = format_ident!("_{}_heartbeat", cdk_name.to_lowercase());
         let body = &self.body;
-        quote::quote! {
+        quote! {
             #[ic_cdk_macros::heartbeat]
-            fn _azle_heartbeat() {
+            fn #function_name() {
                 #body
             }
         }

--- a/src/nodes/act_init_method.rs
+++ b/src/nodes/act_init_method.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{format_ident, quote};
 
 use crate::{nodes::ActFnParam, ToTokenStream, ToTokenStreams};
 
@@ -9,14 +9,20 @@ pub struct ActInitMethod {
     pub body: TokenStream,
 }
 
-impl ToTokenStream<&Vec<String>> for ActInitMethod {
-    fn to_token_stream(&self, keyword_list: &Vec<String>) -> TokenStream {
+pub struct Context<'a> {
+    pub keyword_list: &'a Vec<String>,
+    pub cdk_name: &'a String,
+}
+
+impl ToTokenStream<Context<'_>> for ActInitMethod {
+    fn to_token_stream(&self, context: Context) -> TokenStream {
+        let function_name = format_ident!("_{}_init", context.cdk_name.to_lowercase());
         let body = &self.body;
-        let params = &self.params.to_token_streams(keyword_list);
+        let params = &self.params.to_token_streams(context.keyword_list);
         quote! {
             #[ic_cdk_macros::init]
             #[candid::candid_method(init)]
-            fn _azle_init(#(#params),*) {
+            fn #function_name(#(#params),*) {
                 #body
             }
         }

--- a/src/nodes/act_init_method.rs
+++ b/src/nodes/act_init_method.rs
@@ -9,13 +9,13 @@ pub struct ActInitMethod {
     pub body: TokenStream,
 }
 
-pub struct Context<'a> {
+pub struct TokenStreamContext<'a> {
     pub keyword_list: &'a Vec<String>,
     pub cdk_name: &'a String,
 }
 
-impl ToTokenStream<Context<'_>> for ActInitMethod {
-    fn to_token_stream(&self, context: Context) -> TokenStream {
+impl ToTokenStream<TokenStreamContext<'_>> for ActInitMethod {
+    fn to_token_stream(&self, context: TokenStreamContext) -> TokenStream {
         let function_name = format_ident!("_{}_init", context.cdk_name.to_lowercase());
         let body = &self.body;
         let params = &self.params.to_token_streams(context.keyword_list);

--- a/src/nodes/act_inspect_message_method.rs
+++ b/src/nodes/act_inspect_message_method.rs
@@ -5,17 +5,16 @@ use crate::ToTokenStream;
 
 #[derive(Clone)]
 pub struct ActInspectMessageMethod {
-    pub name: String,
     pub body: TokenStream,
 }
 
-impl ToTokenStream<()> for ActInspectMessageMethod {
-    fn to_token_stream(&self, _: ()) -> TokenStream {
-        let name = format_ident!("_azle_inspect_message_{}", &self.name);
+impl ToTokenStream<&String> for ActInspectMessageMethod {
+    fn to_token_stream(&self, cdk_name: &String) -> TokenStream {
+        let function_name = format_ident!("_{}_inspect_message", cdk_name.to_lowercase(),);
         let body = &self.body;
         quote! {
             #[ic_cdk_macros::inspect_message]
-            fn #name() {
+            fn #function_name() {
                 #body
             }
         }

--- a/src/nodes/act_post_upgrade_method.rs
+++ b/src/nodes/act_post_upgrade_method.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{format_ident, quote};
 
 use crate::{nodes::ActFnParam, ToTokenStream, ToTokenStreams};
 
@@ -9,13 +9,19 @@ pub struct ActPostUpgradeMethod {
     pub body: TokenStream,
 }
 
-impl ToTokenStream<&Vec<String>> for ActPostUpgradeMethod {
-    fn to_token_stream(&self, keyword_list: &Vec<String>) -> TokenStream {
+pub struct TokenStreamContext<'a> {
+    pub keyword_list: &'a Vec<String>,
+    pub cdk_name: &'a String,
+}
+
+impl ToTokenStream<TokenStreamContext<'_>> for ActPostUpgradeMethod {
+    fn to_token_stream(&self, context: TokenStreamContext) -> TokenStream {
+        let function_name = format_ident!("_{}_post_upgrade", context.cdk_name.to_lowercase());
         let body = &self.body;
-        let params = &self.params.to_token_streams(keyword_list);
+        let params = &self.params.to_token_streams(context.keyword_list);
         quote! {
             #[ic_cdk_macros::post_upgrade]
-            fn _azle_post_upgrade(#(#params),*) {
+            fn #function_name(#(#params),*) {
                 #body
             }
         }

--- a/src/nodes/act_pre_upgrade_method.rs
+++ b/src/nodes/act_pre_upgrade_method.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{format_ident, quote};
 
 use crate::ToTokenStream;
 
@@ -8,12 +8,13 @@ pub struct ActPreUpgradeMethod {
     pub body: TokenStream,
 }
 
-impl ToTokenStream<()> for ActPreUpgradeMethod {
-    fn to_token_stream(&self, _: ()) -> TokenStream {
+impl ToTokenStream<&String> for ActPreUpgradeMethod {
+    fn to_token_stream(&self, cdk_name: &String) -> TokenStream {
+        let function_name = format_ident!("_{}_pre_upgrade", cdk_name.to_lowercase());
         let body = &self.body;
         quote! {
             #[ic_cdk_macros::pre_upgrade]
-            fn _azle_pre_upgrade() {
+            fn #function_name() {
                 #body
             }
         }


### PR DESCRIPTION
The CDK Framework generates functions (and sometimes variables) that must include the name of the CDK. Formerly we were just using "Azle" as a carryover from that project. This removes all references to `azle` from the framework in favor of setting the CDK name on the ACT.

For example:

```rust
AbstractCanisterTree {
    cdk_name: "azle".to_string(),
    arrays,
    external_canisters,
    funcs,
    ...
}
```