### PR TITLE
Add opt support to funcs

### DIFF
--- a/src/nodes/data_type_nodes/act_funcs.rs
+++ b/src/nodes/data_type_nodes/act_funcs.rs
@@ -113,6 +113,12 @@ fn generate_func_struct_and_impls(func: &Func, context: &Vec<String>) -> TokenSt
                     .filter(|c| !c.is_whitespace())
                     .collect::<String>()
                     .replacen("Vec<", "Vec::<", 1)
+            } else if rust_type.starts_with("Option") {
+                rust_type
+                    .chars()
+                    .filter(|c| !c.is_whitespace())
+                    .collect::<String>()
+                    .replacen("Option<", "Option::<", 1)
             } else {
                 rust_type.clone()
             };


### PR DESCRIPTION
Without this we can get the following error:

```
error: comparison operators cannot be chained
    --> src/src/lib.rs:2438:23
     |
2438 |                 Option<AzleInline2642418748796565738>::_ty(),
     |                       ^                             ^
     |
help: use `::<...>` instead of `<...>` to specify lifetime, type, or const arguments
     |
2438 |                 Option::<AzleInline2642418748796565738>::_ty(),
     |                       ++
```