### PR TITLE
Remove manual_reply duplication

### DIFF
--- a/src/act/node/canister_method/query_method.rs
+++ b/src/act/node/canister_method/query_method.rs
@@ -38,7 +38,7 @@ impl QueryMethod {
             args.push(quote! {composite = true});
             args.push(quote! {manual_reply = true});
         }
-        if self.is_manual {
+        if self.is_manual && !self.is_async {
             args.push(quote! {manual_reply = true});
         }
         if let Some(guard_function) = &self.guard_function_name {


### PR DESCRIPTION
If a canister method was both async and manual we would double up the `manual_reply` statements like this:

```rust
#[ic_cdk_macros::query(composite = true, manual_reply = true, manual_reply = true)]
```

This ensures that doesn't happen.