### PR TITLE
Modularized code

### DIFF
--- a/src/act/abstract_canister_tree.rs
+++ b/src/act/abstract_canister_tree.rs
@@ -25,39 +25,25 @@ pub struct AbstractCanisterTree {
 impl AbstractCanisterTree {
     pub fn to_token_stream(&self) -> TokenStream {
         let header = &self.header;
-
         let randomness_implementation = random::generate_randomness_implementation();
-
-        let try_into_vm_value_trait = vm_value_conversion::generate_try_into_vm_value();
-        let try_into_vm_value_impls = &self.vm_value_conversion.try_into_vm_value_impls;
-        let try_from_vm_value_trait = vm_value_conversion::generate_try_from_vm_value();
-        let try_from_vm_value_impls = &self.vm_value_conversion.try_from_vm_value_impls;
-
+        let vm_value_conversion = vm_value_conversion::generate(&self.vm_value_conversion);
         let body = &self.body;
-
         let canister_method_decls = self.generate_declarations(self.collect_canister_methods());
         let candid_type_decls = self.generate_declarations(self.collect_candid_types());
         let guard_function_decls = self.generate_declarations(self.guard_functions.clone());
-
-        let candid_file_generation_code =
-            candid_file_generation::generate_candid_file_generation_code();
+        let candid_file_generation_code = candid_file_generation::generate();
 
         quote! {
             #header
 
             #randomness_implementation
 
-            #try_into_vm_value_trait
-            #try_into_vm_value_impls
-            #try_from_vm_value_trait
-            #try_from_vm_value_impls
+            #vm_value_conversion
 
             #body
-
-            #(#canister_method_decls)*
             #(#candid_type_decls)*
+            #(#canister_method_decls)*
             #(#guard_function_decls)*
-
             #candid_file_generation_code
         }
     }

--- a/src/act/candid_file_generation.rs
+++ b/src/act/candid_file_generation.rs
@@ -1,17 +1,14 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-pub fn generate_candid_file_generation_code() -> TokenStream {
+pub fn generate() -> TokenStream {
     quote! {
         candid::export_service!();
 
         // Heavily inspired by https://stackoverflow.com/a/47676844
-        use std::ffi::CString;
-        use std::os::raw::c_char;
-
         #[no_mangle]
-        pub fn _cdk_get_candid_pointer() -> *mut c_char {
-            let c_string = CString::new(__export_service()).unwrap();
+        pub fn _cdk_get_candid_pointer() -> *mut std::os::raw::c_char {
+            let c_string = std::ffi::CString::new(__export_service()).unwrap();
 
             c_string.into_raw()
         }

--- a/src/act/random.rs
+++ b/src/act/random.rs
@@ -3,38 +3,44 @@ use quote::quote;
 
 pub fn generate_randomness_implementation() -> TokenStream {
     quote! {
-        thread_local! {
-            static _CDK_RNG_REF_CELL: std::cell::RefCell<StdRng> = std::cell::RefCell::new(SeedableRng::from_seed([0u8; 32]));
-        }
+        pub mod random {
+            use ic_cdk::api::call::CallResult;
+            use rand::{rngs::StdRng, Rng, SeedableRng};
+            use std::{cell::RefCell, convert::TryInto};
 
-        fn _cdk_custom_getrandom(_buf: &mut [u8]) -> Result<(), getrandom::Error> {
-            _CDK_RNG_REF_CELL.with(|rng_ref_cell| {
-                let mut rng = rng_ref_cell.borrow_mut();
-                rng.fill(_buf);
-            });
+            thread_local! {
+                static _CDK_RNG_REF_CELL: RefCell<StdRng> = RefCell::new(SeedableRng::from_seed([0u8; 32]));
+            }
 
-            Ok(())
-        }
-
-        getrandom::register_custom_getrandom!(_cdk_custom_getrandom);
-
-        fn _cdk_rng_seed() {
-            ic_cdk::spawn(async move {
-                let result: CallResult<(Vec<u8>,)> = ic_cdk::api::call::call(
-                    candid::Principal::from_text("aaaaa-aa").unwrap(),
-                    "raw_rand",
-                    ()
-                ).await;
-
+            fn _cdk_custom_getrandom(_buf: &mut [u8]) -> Result<(), getrandom::Error> {
                 _CDK_RNG_REF_CELL.with(|rng_ref_cell| {
                     let mut rng = rng_ref_cell.borrow_mut();
-
-                    match result {
-                        Ok(randomness) => *rng = SeedableRng::from_seed(randomness.0[..].try_into().unwrap()),
-                        Err(err) => panic!(err)
-                    };
+                    rng.fill(_buf);
                 });
-            });
+
+                Ok(())
+            }
+
+            getrandom::register_custom_getrandom!(_cdk_custom_getrandom);
+
+            pub fn _cdk_rng_seed() {
+                ic_cdk::spawn(async move {
+                    let result: CallResult<(Vec<u8>,)> = ic_cdk::api::call::call(
+                        candid::Principal::from_text("aaaaa-aa").unwrap(),
+                        "raw_rand",
+                        ()
+                    ).await;
+
+                    _CDK_RNG_REF_CELL.with(|rng_ref_cell| {
+                        let mut rng = rng_ref_cell.borrow_mut();
+
+                        match result {
+                            Ok(randomness) => *rng = SeedableRng::from_seed(randomness.0[..].try_into().unwrap()),
+                            Err(err) => panic!(err)
+                        };
+                    });
+                });
+            }
         }
     }
 }

--- a/src/act/vm_value_conversion/mod.rs
+++ b/src/act/vm_value_conversion/mod.rs
@@ -1,7 +1,25 @@
-pub use try_from_vm_value::generate_try_from_vm_value;
-pub use try_into_vm_value::generate_try_into_vm_value;
+use proc_macro2::TokenStream;
 pub use vm_value_conversion::VmValueConversion;
 
 pub mod try_from_vm_value;
 pub mod try_into_vm_value;
 pub mod vm_value_conversion;
+
+pub fn generate(vm_value_conversion: &VmValueConversion) -> TokenStream {
+    let try_into_vm_value_trait = try_into_vm_value::generate_try_into_vm_value();
+    let try_into_vm_value_impls = &vm_value_conversion.try_into_vm_value_impls;
+    let try_from_vm_value_trait = try_from_vm_value::generate_try_from_vm_value();
+    let try_from_vm_value_impls = &vm_value_conversion.try_from_vm_value_impls;
+
+    quote::quote! {
+        pub mod vm_value_conversion {
+            use slotmap::Key as _SlotMapKeyTrait;
+            use std::str::FromStr as _FromStrTrait;
+
+            #try_into_vm_value_trait
+            #try_into_vm_value_impls
+            #try_from_vm_value_trait
+            #try_from_vm_value_impls
+        }
+    }
+}


### PR DESCRIPTION
In order to reduce clashes with user defined code, this creates two sub-modules for the code that seeds randomness, and for vm value conversion. It also removes some `use` statements at the global level.