### PR TITLE
Remove global use statements

### DIFF
--- a/src/act/candid_file_generation.rs
+++ b/src/act/candid_file_generation.rs
@@ -6,12 +6,9 @@ pub fn generate_candid_file_generation_code() -> TokenStream {
         candid::export_service!();
 
         // Heavily inspired by https://stackoverflow.com/a/47676844
-        use std::ffi::CString;
-        use std::os::raw::c_char;
-
         #[no_mangle]
-        pub fn _cdk_get_candid_pointer() -> *mut c_char {
-            let c_string = CString::new(__export_service()).unwrap();
+        pub fn _cdk_get_candid_pointer() -> *mut std::os::raw::c_char {
+            let c_string = std::ffi::CString::new(__export_service()).unwrap();
 
             c_string.into_raw()
         }

--- a/src/act/node/candid/service/method.rs
+++ b/src/act/node/candid/service/method.rs
@@ -74,9 +74,9 @@ impl Method {
             quote! {Result<(), ic_cdk::api::call::RejectionCode>}
         } else {
             if function_return_type.to_string() == "" {
-                quote! {CallResult<()>}
+                quote! {ic_cdk::api::call::CallResult<()>}
             } else {
-                quote! {CallResult<(#function_return_type,)>}
+                quote! {ic_cdk::api::call::CallResult<(#function_return_type,)>}
             }
         };
 

--- a/src/act/random.rs
+++ b/src/act/random.rs
@@ -4,7 +4,7 @@ use quote::quote;
 pub fn generate_randomness_implementation() -> TokenStream {
     quote! {
         thread_local! {
-            static _CDK_RNG_REF_CELL: std::cell::RefCell<StdRng> = std::cell::RefCell::new(SeedableRng::from_seed([0u8; 32]));
+            static _CDK_RNG_REF_CELL: std::cell::RefCell<rand::rngs::StdRng> = std::cell::RefCell::new(rand::SeedableRng::from_seed([0u8; 32]));
         }
 
         fn _cdk_custom_getrandom(_buf: &mut [u8]) -> Result<(), getrandom::Error> {
@@ -20,7 +20,7 @@ pub fn generate_randomness_implementation() -> TokenStream {
 
         fn _cdk_rng_seed() {
             ic_cdk::spawn(async move {
-                let result: CallResult<(Vec<u8>,)> = ic_cdk::api::call::call(
+                let result: ic_cdk::api::call::CallResult<(Vec<u8>,)> = ic_cdk::api::call::call(
                     candid::Principal::from_text("aaaaa-aa").unwrap(),
                     "raw_rand",
                     ()
@@ -30,7 +30,7 @@ pub fn generate_randomness_implementation() -> TokenStream {
                     let mut rng = rng_ref_cell.borrow_mut();
 
                     match result {
-                        Ok(randomness) => *rng = SeedableRng::from_seed(randomness.0[..].try_into().unwrap()),
+                        Ok(randomness) => *rng = rand::SeedableRng::from_seed(randomness.0[..].try_into().unwrap()),
                         Err(err) => panic!(err)
                     };
                 });


### PR DESCRIPTION
This reduce collisions with user defined code by removing global use statements in favor of fully qualified names. 