### PR TITLE
Removed cdk name prefix in cross-canister calls

### DIFF
--- a/src/act/node/candid/service/method.rs
+++ b/src/act/node/candid/service/method.rs
@@ -49,13 +49,7 @@ impl Method {
             quote! {async}
         };
 
-        let function_name = format_ident!(
-            "_{}_{}_{}_{}",
-            context.cdk_name,
-            function_type,
-            canister_name,
-            &self.name
-        );
+        let function_name = format_ident!("{}_{}_{}", function_type, canister_name, &self.name);
 
         let param_types = self.param_types_as_tuple(context, canister_name);
 


### PR DESCRIPTION
We've stopped prefixing everything with `_cdk_` or `_azle_` or `_kybra_` in favor of prefixing user-defined stuff. This is one place we missed.