### PR TITLE
Added `CollectResults`implementation for vecs

### DIFF
--- a/src/act/node/canister_method/canister_method_type.rs
+++ b/src/act/node/canister_method/canister_method_type.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CanisterMethodType {
     Heartbeat,
     Init,


### PR DESCRIPTION
The `CollectResults` trait used to only be implemented for tuples. This adjusts the implementation to support vecs as well.

Additionally I added a few more derives to `CanisterMethodType` for more flexibility.