### PR TITLE
Wrap ManualReply inner type in parens

### DIFF
--- a/src/act/node/candid/type_alias.rs
+++ b/src/act/node/candid/type_alias.rs
@@ -32,7 +32,7 @@ impl Declare<Context> for TypeAlias {
         let type_params_token_stream = self.type_params.get_type_params_token_stream();
         let where_clause_token_stream = self.type_params.get_where_clause_token_stream();
 
-        Some(quote!(type #name #type_params_token_stream #where_clause_token_stream = #alias;))
+        Some(quote!(type #name #type_params_token_stream #where_clause_token_stream = (#alias);))
     }
 
     fn collect_inline_declarations(&self, context: &Context, _: String) -> Vec<Declaration> {

--- a/src/act/node/canister_method/query_or_update_definition.rs
+++ b/src/act/node/canister_method/query_or_update_definition.rs
@@ -53,7 +53,7 @@ impl QueryOrUpdateDefinition {
         let wrapped_return_type =
             if self.is_manual || (self.is_async && context.cdk_name != "kybra") {
                 quote! {
-                    ic_cdk::api::call::ManualReply<#return_type_token>
+                    ic_cdk::api::call::ManualReply<(#return_type_token)>
                 }
             } else {
                 return_type_token


### PR DESCRIPTION
Since #58 we represent void as the empty string which isn't valid rust on its own.