### PR TITLE
Make TryFromVmValue return a generic error

### DIFF
--- a/src/act/vm_value_conversion/try_from_vm_value.rs
+++ b/src/act/vm_value_conversion/try_from_vm_value.rs
@@ -3,11 +3,8 @@ use quote::quote;
 
 pub fn generate_try_from_vm_value() -> TokenStream {
     quote! {
-        pub trait CdkActTryFromVmValue<T, Context> {
-            fn try_from_vm_value(self, context: Context) -> Result<T, CdkActTryFromVmValueError>;
+        pub trait CdkActTryFromVmValue<Ok, Err, Context> {
+            fn try_from_vm_value(self, context: Context) -> Result<Ok, Err>;
         }
-
-        #[derive(Debug)]
-        pub struct CdkActTryFromVmValueError(pub String);
     }
 }


### PR DESCRIPTION
All "from vm value" calls are invoked from a JS context. As a result, we should always be able to represent any possible error as a VM error. As such, the need for an intermediate type is unnecessary and all errors can be represented as a VM-specific error. That means that we need to make this trait return a generic so that it works for Azle, Kybra, etc.